### PR TITLE
🔧 Update GitHub Actions to use the correct private key for app token

### DIFF
--- a/.github/workflows/update-license-year.yml
+++ b/.github/workflows/update-license-year.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/create-github-app-token@v1
         with:
           app-id: ${{ secrets.GHA_APP_ID }}
-          private-key: ${{ secrets.GHA_PRIVATE_KEY }}
+          private-key: ${{ secrets.GHA_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
 
       - name: Make changes (e.g., update LICENSE year)


### PR DESCRIPTION

## 📒 変更点の概要

- GitHub Actions のワークフローで使用するプライベートキーの指定を修正しました。具体的には、`.github/workflows/update-license-year.yml` ファイル内で、`private-key` の値を `${{ secrets.GHA_PRIVATE_KEY }}` から `${{ secrets.GHA_APP_PRIVATE_KEY }}` に変更しました。

## ⚒ 技術的な詳細

- `actions/create-github-app-token@v1` アクションを使用して GitHub App トークンを生成する際に、正しいプライベートキーを使用するように修正しました。この変更により、GitHub App の認証が正しく行われるようになります。

## ⚠ 注意点

- この変更により、GitHub Secrets に `GHA_APP_PRIVATE_KEY` が正しく設定されていることが前提となります。設定が不十分な場合、ワークフローが失敗する可能性がありますのでご注意ください。